### PR TITLE
Added Filters for demonstration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,14 @@ update and delete users.
         1. `@Singleton` for singleton beans identification.
         2. `@Inject` for dependency injection.
     4. Inherited `Managed` for non-dropwizard components like `SampleDownstreamService` for _DI_ identification.
+
+### Iteration 4
+
+1. Added 2 sample filters on Request and response respectively:
+    1. `IdepotencyRequestFilter` filters the request based on the `Idempotency-Key` header.
+        * It expects a unique header for each requests.
+        * If header is not present then it invalidates the request.
+        * If header is already used in a prior requests, it still invalidates the request.
+    2. `PoweredByFilter` adds a header `X-Powered-By` to the response.
+        * If configuration `poweredBy` is present, than value is set to be the same.
+        * Otherwise, it defaults to `ASR`.

--- a/src/main/java/org/asr/experiments/config/IdempotencyCacheConfiguration.java
+++ b/src/main/java/org/asr/experiments/config/IdempotencyCacheConfiguration.java
@@ -1,0 +1,37 @@
+package org.asr.experiments.config;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Singleton;
+import io.dropwizard.lifecycle.Managed;
+
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class IdempotencyCacheConfiguration implements Managed {
+
+    private final LoadingCache<String, String> idempotencyCache;
+
+    public IdempotencyCacheConfiguration() {
+        idempotencyCache = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(10, TimeUnit.SECONDS)
+                .build(
+                        new CacheLoader<>() {
+                            @Override
+                            public String load(String key) {
+                                return key;
+                            }
+                        }
+                );
+    }
+
+    public boolean contains(String key) {
+        return idempotencyCache.getIfPresent(key) != null;
+    }
+
+    public void put(String key, String value) {
+        idempotencyCache.put(key, value);
+    }
+}

--- a/src/main/java/org/asr/experiments/config/TrueConfiguration.java
+++ b/src/main/java/org/asr/experiments/config/TrueConfiguration.java
@@ -6,7 +6,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 public class TrueConfiguration extends Configuration {
+
+    private String poweredBy;
+
     @NotEmpty
     private String template;
 
@@ -59,5 +64,15 @@ public class TrueConfiguration extends Configuration {
     @JsonProperty("http")
     public void setHttpConfig(@Valid @NotNull HttpConfiguration httpConfig) {
         this.httpConfig = httpConfig;
+    }
+
+    @JsonProperty("poweredBy")
+    public Optional<String> getPoweredBy() {
+        return Optional.ofNullable(poweredBy);
+    }
+
+    @JsonProperty("poweredBy")
+    public void setPoweredBy(String poweredBy) {
+        this.poweredBy = poweredBy;
     }
 }

--- a/src/main/java/org/asr/experiments/resources/filter/IdempotencyRequestFilter.java
+++ b/src/main/java/org/asr/experiments/resources/filter/IdempotencyRequestFilter.java
@@ -1,0 +1,21 @@
+package org.asr.experiments.resources.filter;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Response;
+
+public class IdempotencyRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String idempotencyKey = requestContext.getHeaderString("X-Idempotency-Token");
+        if (idempotencyKey == null || idempotencyKey.isEmpty()) {
+            Response response = Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"type\": \"error\", \"message\": \"Idempotency-Key header is missing\"}")
+                    .type("application/json")
+                    .build();
+            throw new WebApplicationException(response);
+        }
+    }
+}

--- a/src/main/java/org/asr/experiments/resources/filter/IdempotencyRequestFilter.java
+++ b/src/main/java/org/asr/experiments/resources/filter/IdempotencyRequestFilter.java
@@ -1,11 +1,25 @@
 package org.asr.experiments.resources.filter;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Response;
+import org.asr.experiments.config.IdempotencyCacheConfiguration;
 
+import java.time.Instant;
+
+/**
+ * Filter that checks if the request has an Idempotency-Key header and if the request with the same key has already been processed.
+ */
 public class IdempotencyRequestFilter implements ContainerRequestFilter {
+
+    private final IdempotencyCacheConfiguration cache;
+
+    @Inject
+    public IdempotencyRequestFilter(IdempotencyCacheConfiguration cache) {
+        this.cache = cache;
+    }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
@@ -17,5 +31,13 @@ public class IdempotencyRequestFilter implements ContainerRequestFilter {
                     .build();
             throw new WebApplicationException(response);
         }
+        if (cache.contains(idempotencyKey)) {
+            Response response = Response.status(Response.Status.CONFLICT)
+                    .entity("{\"type\": \"error\", \"message\": \"Request with the same Idempotency-Key has already been processed\"}")
+                    .type("application/json")
+                    .build();
+            throw new WebApplicationException(response);
+        }
+        cache.put(idempotencyKey, Instant.now().toString());
     }
 }

--- a/src/main/java/org/asr/experiments/resources/filter/PoweredByFilter.java
+++ b/src/main/java/org/asr/experiments/resources/filter/PoweredByFilter.java
@@ -1,0 +1,13 @@
+package org.asr.experiments.resources.filter;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+
+public class PoweredByFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("X-Powered-By", "ASR");
+    }
+}

--- a/src/main/java/org/asr/experiments/resources/filter/PoweredByFilter.java
+++ b/src/main/java/org/asr/experiments/resources/filter/PoweredByFilter.java
@@ -1,13 +1,25 @@
 package org.asr.experiments.resources.filter;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
+import org.asr.experiments.config.TrueConfiguration;
 
+/**
+ * Filter to add a X-Powered-By header to the response from the configuration.
+ */
 public class PoweredByFilter implements ContainerResponseFilter {
+
+    private final TrueConfiguration configuration;
+
+    @Inject
+    public PoweredByFilter(TrueConfiguration configuration) {
+        this.configuration = configuration;
+    }
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
-        responseContext.getHeaders().add("X-Powered-By", "ASR");
+        responseContext.getHeaders().add("X-Powered-By", configuration.getPoweredBy().orElse("ASR"));
     }
 }


### PR DESCRIPTION
Added 2 sample filters.
-  `IdepotencyRequestFilter` filters the request based on the value of `Idempotency-Key` header.
- `PoweredByFilter` adds a header `X-Powered-By` to the response.